### PR TITLE
Support iconStyle Tab Bar property on iOS

### DIFF
--- a/src/views/TabView/TabBarBottom.js
+++ b/src/views/TabView/TabBarBottom.js
@@ -92,6 +92,7 @@ class TabBarBottom extends React.PureComponent {
       renderIcon,
       showIcon,
       showLabel,
+      iconStyle,
     } = this.props;
     if (showIcon === false) {
       return null;
@@ -104,7 +105,7 @@ class TabBarBottom extends React.PureComponent {
         inactiveTintColor={inactiveTintColor}
         renderIcon={renderIcon}
         scene={scene}
-        style={showLabel && useHorizontalTabs ? {} : styles.icon}
+        style={showLabel && useHorizontalTabs ? {} : [styles.icon, iconStyle]}
       />
     );
   };


### PR DESCRIPTION
This property very useful for customising TabBar look, but available only on Android. This commit add support for it for iOS.